### PR TITLE
docs: cname configured when docs is deployed

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -31,3 +31,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book
           publish_branch: docs
+          cname: docs.konomi.ai


### PR DESCRIPTION
fixes #10 
reference: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-add-cname-file-cname