### PR TITLE
fix: added improvements for ip guarding

### DIFF
--- a/client/src/pages/login/index.tsx
+++ b/client/src/pages/login/index.tsx
@@ -73,7 +73,11 @@ function LoginPage() {
   ) => {
     if (err) {
       setLoading(false);
-      setError('Login failed. Double check you email and password combination');
+
+      setError(
+        err.response?.data?.message ??
+          'Login failed. Double check you email and password combination',
+      );
       return;
     }
 

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,7 @@
     "@nestjs/platform-express": "^8.0.0",
     "@nestjs/terminus": "^8.0.6",
     "@prisma/client": "^3.12.0",
+    "@supercharge/request-ip": "^1.2.0",
     "@types/passport": "^1.0.7",
     "ajv": "^8.11.0",
     "bcrypt": "^5.0.1",

--- a/server/src/analytics/analytics.controller.ts
+++ b/server/src/analytics/analytics.controller.ts
@@ -1,4 +1,6 @@
 import { Controller, Get, Query, ValidationPipe } from '@nestjs/common';
+import { Actions, Features } from 'src/auth/constants';
+import { Auth } from 'src/auth/role.decorator';
 import { PrismaService } from 'src/prisma.service';
 import { VALIDATION_PIPE_OPTION } from 'src/utils/consts';
 import { GetAnalyticsReportDto } from './analytics.dto';
@@ -20,6 +22,12 @@ const VIEWS = {
 export class AnalyticsController {
   constructor(private readonly prisma: PrismaService) {}
 
+  @Auth(Actions.READ, [
+    Features.Inventory,
+    Features.Security,
+    Features.Customer,
+    Features.Entry,
+  ])
   @Get()
   async getAnalyticsResult(
     @Query(new ValidationPipe(VALIDATION_PIPE_OPTION))

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -9,7 +9,8 @@ import {
 import { AuthService } from './auth.service';
 import { LoginDto } from './auth.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
-import { SkipIPCheck } from './ip.guard';
+import { IPAllowlistGuard, SkipIPCheck } from './ip.guard';
+import { RequestWithUser } from 'src/types/request';
 
 //TODO: return roles associated as well when that relation has been established
 const SELECT = {
@@ -31,15 +32,19 @@ const SELECT = {
 
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private ipGuard: IPAllowlistGuard,
+  ) {}
 
   @SkipIPCheck()
   @Post('login')
-  async getFeatures(@Body() login: LoginDto) {
+  async getFeatures(@Body() login: LoginDto, @Request() req: RequestWithUser) {
     const user = await this.authService.validateUser(
       login.email,
       login.password,
     );
+    await this.ipGuard.checkRequestIP(req);
     return this.authService.obtainToken(user);
   }
   @UseGuards(JwtAuthGuard)

--- a/server/src/auth/ip.guard.ts
+++ b/server/src/auth/ip.guard.ts
@@ -3,6 +3,7 @@ import {
   CanActivate,
   ExecutionContext,
   Injectable,
+  Logger,
   SetMetadata,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
@@ -14,6 +15,7 @@ const IP_CHECK_KEY = 'shouldCheckIPAddress';
 
 @Injectable()
 export class IPAllowlistGuard implements CanActivate {
+  private readonly logger = new Logger(IPAllowlistGuard.name);
   constructor(
     private readonly ipService: IPService,
     private reflector: Reflector,
@@ -34,11 +36,12 @@ export class IPAllowlistGuard implements CanActivate {
     return this.checkRequestIP(request);
   }
 
-  async checkRequestIP(request: RequestWithUser): Promise<boolean> {
-    const ip = getIPFromRequest(request);
+  async checkRequestIP(request: Request): Promise<boolean> {
+    const ip = getIPFromRequest(request, this.logger);
 
     // If the user is connecting from IPv6
     const hasIP = await this.ipService.isIPInAllowList(ip);
+    this.logger.debug(`Checking IP ${ip} yielded ${hasIP}`);
 
     if (!hasIP) {
       throw new BadRequestException(
@@ -50,24 +53,57 @@ export class IPAllowlistGuard implements CanActivate {
   }
 }
 
-export const getIPFromRequest = (request: any) => {
+/**
+ * Find IP address from the client, if forwarding is identified then use the forwarded IP
+ *
+ * @param request ExpressJS request object
+ * @param logger Optional logger to send debug messages
+ * @returns The IP address of the client
+ */
+export const getIPFromRequest = (request: any, logger?: Logger) => {
   const { headers } = request;
 
   const ip =
-    getClientIPFromForwardRequest(headers) ?? requestIp.getClientIp(request);
+    getClientIPFromForwardRequest(headers, logger) ??
+    requestIp.getClientIp(request);
   if (typeof ip !== 'string') {
     throw new BadRequestException('IP address is not a string');
   }
   return ip.startsWith('::ffff:') ? ip.split('::ffff:')[1] : ip;
 };
 
-const getClientIPFromForwardRequest = (headers: Record<string, string>) => {
+/**
+ * Obtain the IP address from the forwarded request
+ *
+ * @param headers ExpressJS request headers
+ * @param logger Optional logger to send debug messages
+ * @returns string ip address if found, null otherwise
+ */
+const getClientIPFromForwardRequest = (
+  headers: Record<string, string>,
+  logger?: Logger,
+) => {
+  if (process.env.CHRONICLE_IGNORE_FORWARD_HEADERS === 'YES') {
+    logger?.debug('Ignoring forwarded headers due to config');
+    return null;
+  }
+  logger?.debug(
+    `Checking for forwarded IP in headers: ${JSON.stringify({
+      ...headers,
+      authorization: 'REDACTED',
+    })}`,
+  );
   const forwarded = headers['x-forwarded-for'];
   if (typeof forwarded !== 'string') {
+    logger?.debug('No forwarded IP found');
     return null;
   }
   const ips = forwarded.split(',');
   // Get the 2nd last IP from the array
+  // This is because most load balancers will add their own IP to the end of the array
+  // and we want the IP of the client, which is the 2nd last IP
+  // We can add verification for the last IP later if we want to
+  // See https://stackoverflow.com/questions/10849687/understanding-x-forwarded-for
   return ips[ips.length - 2];
 };
 

--- a/server/src/environment.d.ts
+++ b/server/src/environment.d.ts
@@ -2,6 +2,7 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       CHRONICLE_SKIP_AUTH?: 'YES' | 'NO';
+      CHRONICLE_IGNORE_FORWARD_HEADERS?: 'YES' | 'NO';
     }
   }
 }

--- a/server/src/types/request.ts
+++ b/server/src/types/request.ts
@@ -1,0 +1,5 @@
+import { Staff } from '@prisma/client';
+
+export interface RequestWithUser extends Request {
+  user: Partial<Staff>;
+}

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -602,10 +602,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@konomi.ai/c-form@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@konomi.ai/c-form/-/c-form-1.0.2.tgz#14ca70619163a8a456bb97e178f78601b92c7edf"
-  integrity sha512-PcNphjZDW62ERc7jh0OJghlz0A1KXxRlRWe9UE+z7pQdM0H+iKu00pJ5kUjfnnqNPolAX2tWo+z3iKF9okVbsQ==
+"@konomi.ai/c-form@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@konomi.ai/c-form/-/c-form-1.0.4.tgz#be3ebd7885c1bf3a9a3f0d6f6887ea246c2eb811"
+  integrity sha512-RPRWHjSKEBXvsa9kSbfZPZnqgBMLihsUNE8VQKybqYNhRiZzOCotjH24FiaaYTSkFNVaH0XSUR0uDkC562KQcg==
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.8"
@@ -783,6 +783,11 @@
   integrity sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@supercharge/request-ip@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@supercharge/request-ip/-/request-ip-1.2.0.tgz#b8a8164322e09de3fa9b6f556885795c4841a7d4"
+  integrity sha512-wlt6JW69MHqLY2M6Sm/jVyCojNRKq2CBvwH0Hbx24SFhDQQGkgEjeKxVutDxHSyrWixFaOSLXC27euzxijhyMQ==
 
 "@tootallnate/once@1":
   version "1.1.2"


### PR DESCRIPTION
### Related Issue(s)

<!--- Add issue(s) this PR is resolving. If none, remove the line below. If multiple issues, include with multiple resolve #,-->

resolves #268 
resolves #269 

<!--- Keep empty if not applicable -->

### Quick overview of the change

- Make IP guard smarter and handle proxy by default
- Prevent the user from signing in if they are signing in from an unsupported location

### Additional info

I believe we should eventually remove Ip guard as a global guard and just apply it to endpoint as part of the `Auth` decorator, we can support that plus development improvements if we implement #271 and add a wildcard cidr as part of dev seed process
